### PR TITLE
Build 1.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.flatpak-builder/
+build/
+dist/
+poetry/build/
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+BUILD_DEPENDS := poetry setuptools
+
+ID := org.gaphor.Gaphor
+
+BUILD := build
+DIST := dist
+REPO := $(BUILD)/repo
+
+all: $(REPO) dist-flatpaks
+
+install: $(BUILD)/$(ID).flatpak
+	flatpak install --reinstall --assumeyes $(BUILD)/$(ID).flatpak
+
+$(BUILD)/$(ID).flatpak: $(REPO)
+	flatpak build-bundle $(REPO) $@ $(ID)
+
+$(REPO): build-depends.yaml lockfile-depends.yaml org.gaphor.Gaphor.yaml
+	flatpak-builder --force-clean --repo=$@ $(BUILD)/build $(ID).yaml
+	flatpak build-update-repo $(REPO)
+
+$(DIST):
+	mkdir -p $(DIST)
+
+$(DIST)/%.flatpak: $(BUILD)/%.flatpak $(DIST)
+	cp $< $@
+
+dist-flatpaks: $(DIST)/$(ID).flatpak
+
+clean:
+	rm -rf $(BUILD)
+	rm -rf $(DIST)
+	rm -rf .flatpak-builder
+
+setup:
+	flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+	flatpak install flathub org.gnome.Sdk//3.34
+	flatpak install flathub org.gnome.Platform//3.34

--- a/build-depends.yaml
+++ b/build-depends.yaml
@@ -3,19 +3,91 @@ buildsystem: simple
 build-commands:
   - pip3 install --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST}
     poetry
+cleanup:
+  - /bin
+  - /share/man/man1
 sources:
   - type: file
-    url: https://files.pythonhosted.org/packages/ce/6c/888d7c3c1fce3974c88a01a6bc553528c99d3586e098eee23e8383dd11c3/jsonschema-3.1.1-py2.py3-none-any.whl
-    sha256: 94c0a13b4a0616458b42529091624e66700a17f847453e52279e35509a5b7631
+    url: https://files.pythonhosted.org/packages/a2/db/4313ab3be961f7a763066401fb77f7748373b6094076ae2bda2806988af6/attrs-19.3.0-py2.py3-none-any.whl
+    sha256: 08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c
   - type: file
-    url: https://files.pythonhosted.org/packages/f6/d2/40b3fa882147719744e6aa50ac39cf7a22a913cbcba86a0371176c425a3b/importlib_metadata-0.23-py2.py3-none-any.whl
-    sha256: d5f18a79777f3aa179c145737780282e27b508fc8fd688cb17c7a813e8bd39af
+    url: https://files.pythonhosted.org/packages/18/71/0a9df4206a5dc5ae7609c41efddab2270a2c1ff61d39de7591dc7302ef89/CacheControl-0.12.6-py2.py3-none-any.whl
+    sha256: 10d056fa27f8563a271b345207402a6dcce8efab7e5b377e270329c62471b10d
+  - type: file
+    url: https://files.pythonhosted.org/packages/82/e6/badd9af6feee43e76c3445b2621a60d3d99fe0e33fffa8df43590212ea63/cachy-0.3.0-py2.py3-none-any.whl
+    sha256: 338ca09c8860e76b275aff52374330efedc4d5a5e45dc1c5b539c1ead0786fe7
+  - type: file
+    url: https://files.pythonhosted.org/packages/b9/63/df50cac98ea0d5b006c55a399c3bf1db9da7b5a24de7890bc9cfd5dd9e99/certifi-2019.11.28-py2.py3-none-any.whl
+    sha256: 017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3
+  - type: file
+    url: https://files.pythonhosted.org/packages/ff/1d/0b743dadcdf4980b717163fd2d24cd18c1c0c7a78a076268afd7e0e2c25e/cffi-1.14.0-cp37-cp37m-manylinux1_x86_64.whl
+    sha256: 14491a910663bf9f13ddf2bc8f60562d6bc5315c1f09c704937ef17293fb85b0
+  - type: file
+    url: https://files.pythonhosted.org/packages/bc/a9/01ffebfb562e4274b6487b4bb1ddec7ca55ec7510b22e4c51f14098443b8/chardet-3.0.4-py2.py3-none-any.whl
+    sha256: fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691
+  - type: file
+    url: https://files.pythonhosted.org/packages/4b/9d/10a5923c14c4f0faa98216af5262938f468af76101d9cd124ad2054943c7/cleo-0.7.6-py2.py3-none-any.whl
+    sha256: 9443d67e5b2da79b32d820ae41758dd6a25618345cb10b9a022a695e26b291b9
+  - type: file
+    url: https://files.pythonhosted.org/packages/2c/08/b826f8336109e6d3e27193b752e3e23dfbc1aa7fd5f4806e48d37f20794b/clikit-0.4.1-py2.py3-none-any.whl
+    sha256: 80b0bfee42310a715773dded69590c4c33fa9fc9a351fa7c262cb67f21d0758f
+  - type: file
+    url: https://files.pythonhosted.org/packages/45/73/d18a8884de8bffdcda475728008b5b13be7fbef40a2acc81a0d5d524175d/cryptography-2.8-cp34-abi3-manylinux1_x86_64.whl
+    sha256: 7270a6c29199adc1297776937a05b59720e8a782531f1f122f2eb8467f9aab4d
+  - type: file
+    url: https://files.pythonhosted.org/packages/a5/62/bbd2be0e7943ec8504b517e62bab011b4946e1258842bc159e5dfde15b96/html5lib-1.0.1-py2.py3-none-any.whl
+    sha256: 20b159aa3badc9d5ee8f5c647e5efd02ed2a66ab8d354930bd9ff139fc1dc0a3
+  - type: file
+    url: https://files.pythonhosted.org/packages/14/2c/cd551d81dbe15200be1cf41cd03869a46fe7226e7450af7a6545bfc474c9/idna-2.8-py2.py3-none-any.whl
+    sha256: ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c
+  - type: file
+    url: https://files.pythonhosted.org/packages/5f/bb/47f6789a2433e2ae73b7d4c657082fba84945e6af754a99b5e33980ad65a/importlib_metadata-1.1.3-py2.py3-none-any.whl
+    sha256: 7c7f8ac40673f507f349bef2eed21a0e5f01ddf5b2a7356a6c65eb2099b53764
   - type: file
     url: https://files.pythonhosted.org/packages/74/0a/de673c1c987f5779b65ef69052331ec0b0ebd22958bda77a8284be831964/msgpack-0.6.2.tar.gz
     sha256: ea3c2f859346fcd55fc46e96885301d9c2f7a36d453f5d8f2967840efa1e1830
   - type: file
-    url: https://files.pythonhosted.org/packages/14/2c/cd551d81dbe15200be1cf41cd03869a46fe7226e7450af7a6545bfc474c9/idna-2.8-py2.py3-none-any.whl
-    sha256: ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c
+    url: https://files.pythonhosted.org/packages/ae/35/7e580cfed452e3b8c3cca44290adc54b8b5a5b8e37f89da5d24b09318be8/jeepney-0.4.2-py3-none-any.whl
+    sha256: 6f45dce1125cf6c58a1c88123d3831f36a789f9204fbad3172eac15f8ccd08d0
+  - type: file
+    url: https://files.pythonhosted.org/packages/c5/8f/51e89ce52a085483359217bc72cdbf6e75ee595d5b1d4b5ade40c7e018b8/jsonschema-3.2.0-py2.py3-none-any.whl
+    sha256: 4e5b3cf8216f577bee9ce139cbe72eca3ea4f292ec60928ff24758ce626cd163
+  - type: file
+    url: https://files.pythonhosted.org/packages/f1/07/0afb82d449d210a332d126978634470abdd0c754128a9ead8bbe78eb1b43/keyring-20.0.1-py2.py3-none-any.whl
+    sha256: c674f032424b4bffc62abeac5523ec49cc84aed07a480c3233e0baf618efc15c
+  - type: file
+    url: https://files.pythonhosted.org/packages/c8/22/9460e311f340cb62d26a38c419b1381b8593b0bb6b5d1f056938b086d362/lockfile-0.12.2-py2.py3-none-any.whl
+    sha256: 6c3cb24f344923d30b2785d5ad75182c8ea7ac1b6171b08657258ec7429d50fa
+  - type: file
+    url: https://files.pythonhosted.org/packages/25/f8/6009e73f5b08743718d0660a18ecbc44b013a68980347a3835b63e875cdb/msgpack-0.6.2-cp37-cp37m-manylinux1_x86_64.whl
+    sha256: dedf54d72d9e7b6d043c244c8213fe2b8bbfe66874b9a65b39c4cc892dd99dd4
+  - type: file
+    url: https://files.pythonhosted.org/packages/09/b9/ca6434777928cc4e25cd17a8d2a913f3c2877ce54c5a7b7c18bf646ff257/pastel-0.1.1-py2.py3-none-any.whl
+    sha256: a904e1659512cc9880a028f66de77cc813a4c32f7ceb68725cbc8afad57ef7ef
+  - type: file
+    url: https://files.pythonhosted.org/packages/39/7b/88dbb785881c28a102619d46423cb853b46dbccc70d3ac362d99773a78ce/pexpect-4.8.0-py2.py3-none-any.whl
+    sha256: 0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937
+  - type: file
+    url: https://files.pythonhosted.org/packages/e6/d5/451b913307b478c49eb29084916639dc53a88489b993530fed0a66bab8b9/pkginfo-1.5.0.1-py2.py3-none-any.whl
+    sha256: a6d9e40ca61ad3ebd0b72fbadd4fba16e4c0e4df0428c041e01e06eb6ee71f32
+  - type: file
+    url: https://files.pythonhosted.org/packages/00/2b/33501298b9e750bad3526d4aaa210428d556e4dfee4f51729216e22aabf4/poetry-1.0.3-py2.py3-none-any.whl
+    sha256: 995a097097a09fe2d58ebf5770c48e893506351f4d8b7793d558611263ca2fe4
+  - type: file
+    url: https://files.pythonhosted.org/packages/d1/29/605c2cc68a9992d18dada28206eeada56ea4bd07a239669da41674648b6f/ptyprocess-0.6.0-py2.py3-none-any.whl
+    sha256: d7cc528d76e76342423ca640335bd3633420dc1366f258cb31d05e865ef5ca1f
+  - type: file
+    url: https://files.pythonhosted.org/packages/68/9e/49196946aee219aead1290e00d1e7fdeab8567783e83e1b9ab5585e6206a/pycparser-2.19.tar.gz
+    sha256: a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3
+  - type: file
+    url: https://files.pythonhosted.org/packages/40/1c/7dff1d242bf1e19f9c6202f0ba4e6fd18cc7ecb8bc85b17b2d16c806e228/pylev-1.3.0-py2.py3-none-any.whl
+    sha256: 1d29a87beb45ebe1e821e7a3b10da2b6b2f4c79b43f482c2df1a1f748a6e114e
+  - type: file
+    url: https://files.pythonhosted.org/packages/5d/bc/1e58593167fade7b544bfe9502a26dc860940a79ab306e651e7f13be68c2/pyparsing-2.4.6-py2.py3-none-any.whl
+    sha256: c342dccb5250c08d45fd6f8b4a559613ca603b57498511740e65cd11a2e7dcec
+  - type: file
+    url: https://files.pythonhosted.org/packages/8c/46/4e93ab8a379d7efe93f20a0fb8a27bdfe88942cc954ab0210c3164e783e0/pyrsistent-0.14.11.tar.gz
+    sha256: 3ca82748918eb65e2d89f222b702277099aca77e34843c5eb9d52451173970e2
   - type: file
     url: https://files.pythonhosted.org/packages/51/bd/23c926cd341ea6b7dd0b2a00aba99ae0f828be89d72b2190f27c11d4b7fb/requests-2.22.0-py2.py3-none-any.whl
     sha256: 9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31
@@ -23,68 +95,26 @@ sources:
     url: https://files.pythonhosted.org/packages/97/8a/d710f792d6f6ecc089c5e55b66e66c3f2f35516a1ede5a8f54c13350ffb0/requests_toolbelt-0.8.0-py2.py3-none-any.whl
     sha256: 42c9c170abc2cacb78b8ab23ac957945c7716249206f90874651971a4acff237
   - type: file
-    url: https://files.pythonhosted.org/packages/a7/b9/270301a3a87587f09bc3985973f2e362ffa45fa5fcd5128501516b2f5e31/cleo-0.6.8-py2.py3-none-any.whl
-    sha256: 9b7f79f1aa470a025c0d28c76aa225ee9e65028d32f80032e871aa3500df61b8
+    url: https://files.pythonhosted.org/packages/c3/50/8a02cad020e949e6d7105f5f4530d41e3febcaa5b73f8f2148aacb3aeba5/SecretStorage-3.1.2-py3-none-any.whl
+    sha256: b5ec909dde94d4ae2fa26af7c089036997030f0cf0a5cb372b4cccabd81c143b
   - type: file
-    url: https://files.pythonhosted.org/packages/e0/da/55f51ea951e1b7c63a579c09dd7db825bb730ec1fe9c0180fc77bfb31448/urllib3-1.25.6-py2.py3-none-any.whl
-    sha256: 3de946ffbed6e6746608990594d08faac602528ac7015ac28d33cee6a45b7398
-  - type: file
-    url: https://files.pythonhosted.org/packages/45/dc/3241eef99eb45f1def35cf93af35d1cf9ef4c0991792583b8f33ea41b092/more_itertools-7.2.0-py3-none-any.whl
-    sha256: 92b8c4b06dac4f0611c0729b2f2ede52b2e1bac1ab48f089c7ddc12e26bb60c4
-  - type: file
-    url: https://files.pythonhosted.org/packages/a2/db/4313ab3be961f7a763066401fb77f7748373b6094076ae2bda2806988af6/attrs-19.3.0-py2.py3-none-any.whl
-    sha256: 08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c
-  - type: file
-    url: https://files.pythonhosted.org/packages/26/37/8ce3e7b330078b6797a34e79a80a8ad6935e404a3b903765417182c9ce19/cachy-0.2.0-py2.py3-none-any.whl
-    sha256: b71e8e7ddb5b386e23e81befdfac8a93885406139b8681bedc17b3444fcb8fca
-  - type: file
-    url: https://files.pythonhosted.org/packages/5e/f0/2c193ed1f17c97ae539da7e1c2d48b80d8cccb1917163b26a91ca4355aa6/CacheControl-0.12.5.tar.gz
-    sha256: cef77effdf51b43178f6a2d3b787e3734f98ade253fa3187f3bb7315aaa42ff7
-  - type: file
-    url: https://files.pythonhosted.org/packages/18/b0/8146a4f8dd402f60744fa380bc73ca47303cccf8b9190fd16a827281eac2/certifi-2019.9.11-py2.py3-none-any.whl
-    sha256: fd7c7c74727ddcf00e9acd26bba8da604ffec95bf1c2144e67aff7a8b50e6cef
-  - type: file
-    url: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
-    sha256: a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78
+    url: https://files.pythonhosted.org/packages/3d/72/1c1498c1e908e0562b1e1cd30012580baa7d33b5b0ffdbeb5fde2462cc71/setuptools-45.2.0-py3-none-any.whl
+    sha256: 316484eebff54cc18f322dea09ed031b7e3eb00811b19dcedb09bc09bba7d93d
   - type: file
     url: https://files.pythonhosted.org/packages/2d/ac/e8a34d4b3d24bf554f40651b2aac549a3fc7223725bf10fbdfe2083b6372/shellingham-1.3.1-py2.py3-none-any.whl
     sha256: 77d37a4fd287c1e663006f7ecf1b9deca9ad492d0082587bd813c44eb49e4e62
   - type: file
-    url: https://files.pythonhosted.org/packages/e6/d5/451b913307b478c49eb29084916639dc53a88489b993530fed0a66bab8b9/pkginfo-1.5.0.1-py2.py3-none-any.whl
-    sha256: a6d9e40ca61ad3ebd0b72fbadd4fba16e4c0e4df0428c041e01e06eb6ee71f32
-  - type: file
-    url: https://files.pythonhosted.org/packages/40/1c/7dff1d242bf1e19f9c6202f0ba4e6fd18cc7ecb8bc85b17b2d16c806e228/pylev-1.3.0-py2.py3-none-any.whl
-    sha256: 1d29a87beb45ebe1e821e7a3b10da2b6b2f4c79b43f482c2df1a1f748a6e114e
-  - type: file
-    url: https://files.pythonhosted.org/packages/11/fa/0160cd525c62d7abd076a070ff02b2b94de589f1a9789774f17d7c54058e/pyparsing-2.4.2-py2.py3-none-any.whl
-    sha256: d9338df12903bbf5d65a0e4e87c2161968b10d2e489652bb47001d82a9b028b4
-  - type: file
-    url: https://files.pythonhosted.org/packages/a5/62/bbd2be0e7943ec8504b517e62bab011b4946e1258842bc159e5dfde15b96/html5lib-1.0.1-py2.py3-none-any.whl
-    sha256: 20b159aa3badc9d5ee8f5c647e5efd02ed2a66ab8d354930bd9ff139fc1dc0a3
-  - type: file
-    url: https://files.pythonhosted.org/packages/74/3d/1ee25a26411ba0401b43c6376d2316a71addcc72ef8690b101b4ea56d76a/zipp-0.6.0-py2.py3-none-any.whl
-    sha256: f06903e9f1f43b12d371004b4ac7b06ab39a44adc747266928ae6debfa7b3335
-  - type: file
-    url: https://files.pythonhosted.org/packages/bc/a9/01ffebfb562e4274b6487b4bb1ddec7ca55ec7510b22e4c51f14098443b8/chardet-3.0.4-py2.py3-none-any.whl
-    sha256: fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691
-  - type: file
-    url: https://files.pythonhosted.org/packages/8c/46/4e93ab8a379d7efe93f20a0fb8a27bdfe88942cc954ab0210c3164e783e0/pyrsistent-0.14.11.tar.gz
-    sha256: 3ca82748918eb65e2d89f222b702277099aca77e34843c5eb9d52451173970e2
+    url: https://files.pythonhosted.org/packages/65/eb/1f97cb97bfc2390a276969c6fae16075da282f5058082d4cb10c6c5c1dba/six-1.14.0-py2.py3-none-any.whl
+    sha256: 8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c
   - type: file
     url: https://files.pythonhosted.org/packages/3e/30/7c2693fc50bd466285ec22bf02ee344be1bde3e2e8267e302fdc82d11f2d/tomlkit-0.5.8-py2.py3-none-any.whl
     sha256: 96e6369288571799a3052c1ef93b9de440e1ab751aa045f435b55e9d3bcd0690
   - type: file
-    url: https://files.pythonhosted.org/packages/09/b9/ca6434777928cc4e25cd17a8d2a913f3c2877ce54c5a7b7c18bf646ff257/pastel-0.1.1-py2.py3-none-any.whl
-    sha256: a904e1659512cc9880a028f66de77cc813a4c32f7ceb68725cbc8afad57ef7ef
+    url: https://files.pythonhosted.org/packages/e8/74/6e4f91745020f967d09332bb2b8b9b10090957334692eb88ea4afe91b77f/urllib3-1.25.8-py2.py3-none-any.whl
+    sha256: 2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc
   - type: file
-    url: https://files.pythonhosted.org/packages/c8/22/9460e311f340cb62d26a38c419b1381b8593b0bb6b5d1f056938b086d362/lockfile-0.12.2-py2.py3-none-any.whl
-    sha256: 6c3cb24f344923d30b2785d5ad75182c8ea7ac1b6171b08657258ec7429d50fa
+    url: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
+    sha256: a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78
   - type: file
-    url: https://files.pythonhosted.org/packages/c9/76/214acc400055aa0045ed21ce25378225b1887c5c091f99476955bf9f6984/poetry-0.12.17-py2.py3-none-any.whl
-    sha256: 0133cd4edc77e955de8cd91203b6728f8365e2849d7fa7da1bfbc14b6529ab43
-  - type: file
-    url: https://files.pythonhosted.org/packages/73/fb/00a976f728d0d1fecfe898238ce23f502a721c0ac0ecfedb80e0d88c64e9/six-1.12.0-py2.py3-none-any.whl
-    sha256: 3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c
-cleanup:
-  - /bin
-  - /share/man/man1
+    url: https://files.pythonhosted.org/packages/46/42/f2dd964b2a6b1921b08d661138148c1bcd3f038462a44019416f2342b618/zipp-2.2.0-py36-none-any.whl
+    sha256: d65287feb793213ffe11c0f31b81602be31448f38aeb8ffc2eb286c4f6f6657e

--- a/lockfile-depends.yaml
+++ b/lockfile-depends.yaml
@@ -2,26 +2,26 @@ name: poetry-deps
 buildsystem: simple
 build-commands:
   - pip3 install --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST}
-    future gaphas importlib-metadata more-itertools pycairo pygobject zipp
+    gaphas generic importlib-metadata==1.5.0 pycairo pygobject typing-extensions zipp
 sources:
   - type: file
-    url: https://files.pythonhosted.org/packages/90/52/e20466b85000a181e1e144fd8305caf2cf475e2f9674e797b222f8105f5f/future-0.17.1.tar.gz
-    sha256: 67045236dcfd6816dc439556d009594abf643e5eb48992e36beac09c2ca659b8
+    url: https://files.pythonhosted.org/packages/2e/1a/0fa68ef2a9047d70c6b2bd2aae9c0918d9f5c3f1c5d1f6244b58ec1d4605/gaphas-2.0.1-py3-none-any.whl
+    sha256: 36ca8b6fbad7e200101f6f585699206b2f8e8f042116b67df77d2b487e33c884
   - type: file
-    url: https://files.pythonhosted.org/packages/65/81/d1d7c68c7ad64b0ef35659fe7a6aaa47635dab6aec0cf12dcf7d0ee5932a/gaphas-1.1.1-py2.py3-none-any.whl
-    sha256: 210d36249f56ade49d394c79ae7f62a2ecec85ef75b87ac3f2ff231ce6fcaaa2
+    url: https://files.pythonhosted.org/packages/b5/76/0a9388e6dde0b00202da3585ff7441bddb9b39a3435486742ab5e4609a6e/generic-1.0.0-py3-none-any.whl
+    sha256: a8dbb3133929223149272fcc70a95967cf3b24e3fa12601f91c67fb61efe29d4
   - type: file
-    url: https://files.pythonhosted.org/packages/f6/d2/40b3fa882147719744e6aa50ac39cf7a22a913cbcba86a0371176c425a3b/importlib_metadata-0.23-py2.py3-none-any.whl
-    sha256: d5f18a79777f3aa179c145737780282e27b508fc8fd688cb17c7a813e8bd39af
+    url: https://files.pythonhosted.org/packages/8b/03/a00d504808808912751e64ccf414be53c29cad620e3de2421135fcae3025/importlib_metadata-1.5.0-py2.py3-none-any.whl
+    sha256: b97607a1a18a5100839aec1dc26a1ea17ee0d93b20b0f008d80a5a050afb200b
   - type: file
-    url: https://files.pythonhosted.org/packages/45/dc/3241eef99eb45f1def35cf93af35d1cf9ef4c0991792583b8f33ea41b092/more_itertools-7.2.0-py3-none-any.whl
-    sha256: 92b8c4b06dac4f0611c0729b2f2ede52b2e1bac1ab48f089c7ddc12e26bb60c4
-  - type: file
-    url: https://files.pythonhosted.org/packages/3c/1a/c0478ecab31baae50fda9956547788afbd0ca563adc52c9b03cab30f17eb/pycairo-1.18.2.tar.gz
-    sha256: dcb853fd020729516e8828ad364084e752327d4cff8505d20b13504b32b16531
+    url: https://files.pythonhosted.org/packages/25/95/ac361f06789c7dad19c37f4d7043df9275f416dffcdc44e22c3befeb7b08/pycairo-1.19.0.tar.gz
+    sha256: 4f5ba9374a46c98729dd3727d993f5e17ed0286fd6738ed464fe4efa0612d19c
   - type: file
     url: https://files.pythonhosted.org/packages/46/8a/b183f3edc812d4d28c8b671a922b5bc2863be5d38c56b3ad9155815e78dd/PyGObject-3.34.0.tar.gz
     sha256: 2acb0daf2b3a23a90f52066cc23d1053339fee2f5f7f4275f8baa3704ae0c543
   - type: file
-    url: https://files.pythonhosted.org/packages/74/3d/1ee25a26411ba0401b43c6376d2316a71addcc72ef8690b101b4ea56d76a/zipp-0.6.0-py2.py3-none-any.whl
-    sha256: f06903e9f1f43b12d371004b4ac7b06ab39a44adc747266928ae6debfa7b3335
+    url: https://files.pythonhosted.org/packages/03/92/705fe8aca27678e01bbdd7738173b8e7df0088a2202c80352f664630d638/typing_extensions-3.7.4.1-py3-none-any.whl
+    sha256: cf8b63fedea4d89bab840ecbb93e75578af28f76f66c35889bd7065f5af88575
+  - type: file
+    url: https://files.pythonhosted.org/packages/46/42/f2dd964b2a6b1921b08d661138148c1bcd3f038462a44019416f2342b618/zipp-2.2.0-py36-none-any.whl
+    sha256: d65287feb793213ffe11c0f31b81602be31448f38aeb8ffc2eb286c4f6f6657e

--- a/org.gaphor.Gaphor.yaml
+++ b/org.gaphor.Gaphor.yaml
@@ -18,19 +18,18 @@ modules:
   - name: gaphor
     buildsystem: simple
     build-commands:
-      - 'poetry config settings.virtualenvs.create false && poetry build'
+      - 'poetry config virtualenvs.create false && poetry build'
       - 'pip3 install --no-index --prefix=${FLATPAK_DEST} ./dist/gaphor*.whl'
     sources:
       - type: git
-        tag: 1.1.1
         url: https://github.com/gaphor/gaphor
-        commit: 60a3caa96d5e8b5302a39bfc4deba22d54d2f1ff
+        commit: aac3e76053879381d24199950cb156bc01646aa3
 
     post-install:
       - install -Dm644 flatpak/org.gaphor.Gaphor.appdata.xml /app/share/metainfo/org.gaphor.Gaphor.appdata.xml
       - install -Dm644 flatpak/org.gaphor.Gaphor.desktop /app/share/applications/org.gaphor.Gaphor.desktop
-      - install -Dm644 gaphor/ui/pixmaps/gaphor-24x24.png /app/share/icons/hicolor/24x24/apps/gaphor.png
-      - install -Dm644 gaphor/ui/pixmaps/gaphor-48x48.png /app/share/icons/hicolor/48x48/apps/gaphor.png
-      - install -Dm644 gaphor/ui/pixmaps/gaphor-96x96.png /app/share/icons/hicolor/96x96/apps/gaphor.png
-      - install -Dm644 gaphor/ui/pixmaps/gaphor-256x256.png /app/share/icons/hicolor/256x256/apps/gaphor.png
-      - install -Dm644 iconsrc/gaphor.svg /app/share/icons/hicolor/scalable/apps/gaphor.svg
+      - install -Dm644 logos/gaphor-24x24.png /app/share/icons/hicolor/24x24/apps/gaphor.png
+      - install -Dm644 logos/gaphor-48x48.png /app/share/icons/hicolor/48x48/apps/gaphor.png
+      - install -Dm644 logos/gaphor-96x96.png /app/share/icons/hicolor/96x96/apps/gaphor.png
+      - install -Dm644 logos/gaphor-256x256.png /app/share/icons/hicolor/256x256/apps/gaphor.png
+      - install -Dm644 logos/gaphor.svg /app/share/icons/hicolor/scalable/apps/gaphor.svg

--- a/org.gaphor.Gaphor.yaml
+++ b/org.gaphor.Gaphor.yaml
@@ -23,11 +23,12 @@ modules:
     sources:
       - type: git
         url: https://github.com/gaphor/gaphor
-        commit: aac3e76053879381d24199950cb156bc01646aa3
+        commit: 8358e12f54a61836d130e9c143b7386cd8499dcc
 
     post-install:
       - install -Dm644 flatpak/org.gaphor.Gaphor.appdata.xml /app/share/metainfo/org.gaphor.Gaphor.appdata.xml
       - install -Dm644 flatpak/org.gaphor.Gaphor.desktop /app/share/applications/org.gaphor.Gaphor.desktop
+      - install -Dm644 flatpak/org.gaphor.Gaphor.xml /app/share/mime/packages/org.gaphor.Gaphor.xml
       - install -Dm644 logos/gaphor-24x24.png /app/share/icons/hicolor/24x24/apps/gaphor.png
       - install -Dm644 logos/gaphor-48x48.png /app/share/icons/hicolor/48x48/apps/gaphor.png
       - install -Dm644 logos/gaphor-96x96.png /app/share/icons/hicolor/96x96/apps/gaphor.png

--- a/poetry/depends.sh
+++ b/poetry/depends.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -euo pipefail
+
+POETRY_VERSION=1.0.3
+mkdir -p build
+pip3 download -q --dest build poetry==${POETRY_VERSION}
+
+cat << EOF
+name: python3-poetry
+buildsystem: simple
+build-commands:
+  - pip3 install --no-index --find-links="file://\${PWD}" --prefix=\${FLATPAK_DEST}
+    poetry
+cleanup:
+  - /bin
+  - /share/man/man1
+sources:
+EOF
+
+ls build | awk -F- '{ print $1 " " $0 }' | \
+while read DEP FILE
+do
+	curl -sSfL https://pypi.org/pypi/${DEP}/json | jq -r '.releases[][] | select(.filename == "'${FILE}'") | "\(.digests.sha256) \(.url)"'
+done | \
+while read SHA URL
+do
+	echo "  - type: file"
+	echo "    url: ${URL}"
+	echo "    sha256: ${SHA}"
+done


### PR DESCRIPTION
Changes required to build against Gaphor master.

I also added a small script to fix dependency resolution for poetry.

Did a quick hack to the lockfile-depends.yaml file, so it will ensure the right version of importlib_metadata is installed.