### PR TITLE
Add GtkSourceView as a dependency

### DIFF
--- a/org.gaphor.Gaphor.yaml
+++ b/org.gaphor.Gaphor.yaml
@@ -14,6 +14,12 @@ cleanup:
   - /lib/debug
 modules:
   - gaphor-bin.yaml
+  - name: gtksourceview4
+    buildsystem: meson
+    sources:
+      - type: archive
+        url: https://download.gnome.org/sources/gtksourceview/4.8/gtksourceview-4.8.1.tar.xz
+        sha256: d163d71b5fcafbc5b1eec6dd841edbdbcddd3a7511cd5fdcffd86b8bbfe69ac1
   - name: gaphor-extras
     buildsystem: simple
     sources:


### PR DESCRIPTION
This branch can be used to release the next version of Gaphor in order to include support for https://github.com/gaphor/gaphor/pull/928.