### PR TITLE
Add more appdata information

### DIFF
--- a/share/org.gaphor.Gaphor.appdata.xml
+++ b/share/org.gaphor.Gaphor.appdata.xml
@@ -30,7 +30,10 @@
     </screenshot>
   </screenshots>
   <url type="homepage">https://gaphor.org</url>
+  <url type="bugtracker">https://github.com/gaphor/gaphor/issues</url>
   <url type="help">https://gaphor.readthedocs.io</url>
+  <url type="donation">https://github.com/sponsors/danyeaw</url>
+  <url type="translate">https://hosted.weblate.org/projects/gaphor/gaphor</url>
   <description>
     <p>Gaphor is a free GTK application written in Python aimed at UML and SysML modeling. It is designed to be easy to use, while still being powerful. 
       Gaphor implements a fully-compliant UML 2 data model, and can be used to draw, design and visualize different aspects of a system as well as create highly complex models.


### PR DESCRIPTION
Hi, the original purpose of this PR was to add  `</translation>` tag, which indicates the availability of the translation, to appdata.
However, since the project it's using babel, which is not supported according to the [documentation](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-translation), instead of gettext.
I only added Weblate's link, the donation link (GitHub Sponsors) and GitHub's issues.