### PR TITLE
Install symbolic Gaphor icon

### DIFF
--- a/logos/org.gaphor.Gaphor-symbolic.svg
+++ b/logos/org.gaphor.Gaphor-symbolic.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg height="16px" viewBox="0 0 16 16" width="16px" xmlns="http://www.w3.org/2000/svg">
+    <g fill="#241f31">
+        <path d="m 2 3 h 6 c 0.550781 0 1 0.449219 1 1 v 8 c 0 0.550781 -0.449219 1 -1 1 h -6 c -0.550781 0 -1 -0.449219 -1 -1 v -8 c 0 -0.550781 0.449219 -1 1 -1 z m 0 0"/>
+        <path d="m 4 9 h 9 v -2 h -9 z m 0 0"/>
+        <path d="m 16 8 l -4 -3 v 6 z m 0 0"/>
+    </g>
+</svg>

--- a/org.gaphor.Gaphor.yaml
+++ b/org.gaphor.Gaphor.yaml
@@ -39,6 +39,8 @@ modules:
         path: logos/gaphor-256x256.png
       - type: file
         path: logos/org.gaphor.Gaphor.svg
+      - type: file
+        path: logos/org.gaphor.Gaphor-symbolic.svg
     build-commands:
       - install -Dm644 org.gaphor.Gaphor.appdata.xml /app/share/metainfo/org.gaphor.Gaphor.appdata.xml
       - install -Dm644 org.gaphor.Gaphor.desktop /app/share/applications/org.gaphor.Gaphor.desktop
@@ -48,3 +50,4 @@ modules:
       - install -Dm644 gaphor-96x96.png /app/share/icons/hicolor/96x96/apps/org.gaphor.Gaphor.png
       - install -Dm644 gaphor-256x256.png /app/share/icons/hicolor/256x256/apps/org.gaphor.Gaphor.png
       - install -Dm644 org.gaphor.Gaphor.svg /app/share/icons/hicolor/scalable/apps/org.gaphor.Gaphor.svg
+      - install -Dm644 org.gaphor.Gaphor-symbolic.svg /app/share/icons/hicolor/symbolic/apps/org.gaphor.Gaphor-symbolic.svg


### PR DESCRIPTION
The symbolic icon created by Tobias was missing from the Flatpak package.