### PR TITLE
Add release notes to appdata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ version:
 	sed -i "s/^VERSION .*/VERSION := ${VERSION}/" Makefile
 
 appdata:
-	sed -i '/  <releases>/a \ \ \ \ <release version="$(VERSION)" date="$(shell date +%Y-%m-%d)"/>' share/org.gaphor.Gaphor.appdata.xml
+	python3 update-appdata.py $(VERSION)
 
 gaphor-bin.yaml: depends.sh
 	bash depends.sh ${VERSION} > gaphor-bin.yaml

--- a/share/org.gaphor.Gaphor.appdata.xml
+++ b/share/org.gaphor.Gaphor.appdata.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version='1.0' encoding='utf-8'?>
 <component type="desktop-application">
   <id>org.gaphor.Gaphor</id>
   <launchable type="desktop-id">org.gaphor.Gaphor.desktop</launchable>
@@ -57,7 +57,6 @@
       Gaphor provides four modeling languages: UML, SysML, RAAML and C4 and
       makes them accessible to beginners.
     </p>
-
     <p xml:lang="es">
       Gaphor es una aplicación de modelado UML, SysML, RAAML y C4. Está
       diseñado para ser fácil de usar, sin dejar de ser potente. Gaphor
@@ -70,7 +69,6 @@
       Gaphor ofrece cuatro lenguajes de modelado: UML, SysML, RAAML y C4 y
       los hace accesibles a los principiantes.
     </p>
-
     <p xml:lang="hr">
       Gaphor je program za UML, SysML, RAAML i C4 modeliranje. Jednostavan u
       upotrebi, a istovremeno moćan alat. Gaphor implementira potpuno usklađen
@@ -82,7 +80,6 @@
       Gaphor nudi četiri jezika za modeliranje: UML, SysML, RAAML i C4 te
       omogućuje pristup početnicima.
     </p>
-
     <p xml:lang="hu">
       A Gaphor egy UML, SysML, RAAML és C4 modellező alkalmazás. Úgy tervezték, 
       hogy könnyen használható legyen, ugyanakkor erős legyen. A Gaphor egy 
@@ -95,50 +92,49 @@
       A Gaphor négy modellezési nyelvet kínál: UML, SysML, RAAML és C4, és 
       elérhetővé teszi a kezdők számára. 
     </p>
-
   </description>
   <releases>
-    <release version="2.18.1" date="2023-04-29"/>
-    <release version="2.18.0" date="2023-04-07"/>
-    <release version="2.17.0" date="2023-02-25"/>
-    <release version="2.16.0" date="2023-02-04"/>
-    <release version="2.15.0" date="2023-01-08"/>
-    <release version="2.14.2" date="2022-12-28"/>
-    <release version="2.14.1" date="2022-12-28"/>
-    <release version="2.14.0" date="2022-12-24"/>
-    <release version="2.13.0" date="2022-11-27"/>
-    <release version="2.12.1" date="2022-10-07"/>
-    <release version="2.12.0" date="2022-09-25"/>
-    <release version="2.11.0" date="2022-07-09"/>
-    <release version="2.10.0" date="2022-05-22"/>
-    <release version="2.9.2" date="2022-03-18"/>
-    <release version="2.9.1" date="2022-03-17"/>
-    <release version="2.9.0" date="2022-03-17"/>
-    <release version="2.8.2" date="2022-01-30"/>
-    <release version="2.8.1" date="2022-01-18"/>
-    <release version="2.8.0" date="2022-01-15"/>
-    <release version="2.7.1" date="2021-12-01"/>
-    <release version="2.7.0" date="2021-11-26"/>
-    <release version="2.6.5" date="2021-10-18"/>
-    <release version="2.6.4" date="2021-10-03"/>
-    <release version="2.6.2" date="2021-10-01"/>
-    <release version="2.6.1" date="2021-09-25"/>
-    <release version="2.6.0" date="2021-09-14"/>
-    <release version="2.5.1" date="2021-07-04"/>
-    <release version="2.5.0" date="2021-06-29"/>
-    <release version="2.4.2" date="2021-05-23"/>
-    <release version="2.4.1" date="2021-05-10"/>
-    <release version="2.4.0" date="2021-05-01"/>
-    <release version="2.3.2" date="2021-03-29"/>
-    <release version="2.3.1" date="2021-03-28"/>
-    <release version="2.3.0" date="2021-03-20"/>
-    <release version="2.2.2" date="2021-02-07"/>
-    <release version="2.2.1" date="2021-01-26"/>
-    <release version="2.2.0" date="2021-01-23"/>
-    <release version="2.1.1" date="2020-11-30"/>
-    <release version="2.1.0" date="2020-11-29"/>
-    <release version="2.0.1" date="2020-08-27"/>
-    <release version="2.0.0" date="2020-07-31"/>
+    <release version="2.18.1" date="2023-04-29" />
+    <release version="2.18.0" date="2023-04-07" />
+    <release version="2.17.0" date="2023-02-25" />
+    <release version="2.16.0" date="2023-02-04" />
+    <release version="2.15.0" date="2023-01-08" />
+    <release version="2.14.2" date="2022-12-28" />
+    <release version="2.14.1" date="2022-12-28" />
+    <release version="2.14.0" date="2022-12-24" />
+    <release version="2.13.0" date="2022-11-27" />
+    <release version="2.12.1" date="2022-10-07" />
+    <release version="2.12.0" date="2022-09-25" />
+    <release version="2.11.0" date="2022-07-09" />
+    <release version="2.10.0" date="2022-05-22" />
+    <release version="2.9.2" date="2022-03-18" />
+    <release version="2.9.1" date="2022-03-17" />
+    <release version="2.9.0" date="2022-03-17" />
+    <release version="2.8.2" date="2022-01-30" />
+    <release version="2.8.1" date="2022-01-18" />
+    <release version="2.8.0" date="2022-01-15" />
+    <release version="2.7.1" date="2021-12-01" />
+    <release version="2.7.0" date="2021-11-26" />
+    <release version="2.6.5" date="2021-10-18" />
+    <release version="2.6.4" date="2021-10-03" />
+    <release version="2.6.2" date="2021-10-01" />
+    <release version="2.6.1" date="2021-09-25" />
+    <release version="2.6.0" date="2021-09-14" />
+    <release version="2.5.1" date="2021-07-04" />
+    <release version="2.5.0" date="2021-06-29" />
+    <release version="2.4.2" date="2021-05-23" />
+    <release version="2.4.1" date="2021-05-10" />
+    <release version="2.4.0" date="2021-05-01" />
+    <release version="2.3.2" date="2021-03-29" />
+    <release version="2.3.1" date="2021-03-28" />
+    <release version="2.3.0" date="2021-03-20" />
+    <release version="2.2.2" date="2021-02-07" />
+    <release version="2.2.1" date="2021-01-26" />
+    <release version="2.2.0" date="2021-01-23" />
+    <release version="2.1.1" date="2020-11-30" />
+    <release version="2.1.0" date="2020-11-29" />
+    <release version="2.0.1" date="2020-08-27" />
+    <release version="2.0.0" date="2020-07-31" />
     <release version="1.2.0" date="2020-03-15" />
     <release version="1.1.1" date="2019-11-02" />
     <release version="1.1.0" date="2019-10-26" />

--- a/share/org.gaphor.Gaphor.appdata.xml
+++ b/share/org.gaphor.Gaphor.appdata.xml
@@ -94,11 +94,105 @@
     </p>
   </description>
   <releases>
-    <release version="2.18.1" date="2023-04-29" />
-    <release version="2.18.0" date="2023-04-07" />
-    <release version="2.17.0" date="2023-02-25" />
-    <release version="2.16.0" date="2023-02-04" />
-    <release version="2.15.0" date="2023-01-08" />
+    <release version="2.18.1" date="2023-04-29">
+      <description>
+        <ul>
+          <li>Make operations visible on Blocks</li>
+          <li>A quick fix for crashes in the CSS editor, disable autocomplete</li>
+          <li>Fix doc translation catalogs not found</li>
+          <li>Fix encoding warnings for no encoding argument</li>
+          <li>Update AppImage build with GTK 4.10</li>
+          <li>Add non-goals to README</li>
+          <li>Enable translation of docs, and add Crotian, German, and Dutch</li>
+          <li>Updates to most translations and add Tamil</li>
+        </ul>
+      </description>
+      <url>https://github.com/gaphor/gaphor/releases/tag/2.18.1</url>
+    </release>
+    <release version="2.18.0" date="2023-04-07">
+      <description>
+        <ul>
+          <li>Support for manually resolving Git merge conflicts</li>
+          <li>Drop support for GTK3, bundle macOS with GTK4</li>
+          <li>Enable middle-click mouse scrolling of diagrams</li>
+          <li>Support for changing the spoken language in a model</li>
+          <li>Add diagrams in diagrams</li>
+          <li>Upgrade development build to GNOME 44</li>
+          <li>Clean up application architecture for copy service</li>
+          <li>Css editor dark mode</li>
+          <li>macOS: update notarize, staple, and cert actions</li>
+          <li>Just load modules for gaphor.modules entry points</li>
+          <li>Finnish, Dutch, Spanish, Polish, Portuguese (BRA) translation update</li>
+          <li>Toggle the "no tabs" background based on notebook activity</li>
+          <li>Fix drag from model browser</li>
+          <li>Fix orthogonal lines during copy/paste</li>
+          <li>Update diagram directly when partitions change</li>
+          <li>Make main window always available to avoid warnings</li>
+        </ul>
+      </description>
+      <url>https://github.com/gaphor/gaphor/releases/tag/2.18.0</url>
+    </release>
+    <release version="2.17.0" date="2023-02-25">
+      <description>
+        <ul>
+          <li>Add support for diagram metadata</li>
+          <li>macOS: Fix freeze creating new diagram</li>
+          <li>Properly unsubscribe when property page is removed</li>
+          <li>Package GSettings daemon schemas for AppImage</li>
+          <li>Consider only default modifiers in toolbox shortcuts</li>
+          <li>New status page icon</li>
+          <li>Workaround removing skip-changelog labels</li>
+          <li>Update gvsbuild to version 2023.2.0</li>
+          <li>meta: Add .doap-file</li>
+          <li>Update "Keep model in sync" design principle</li>
+          <li>Update to using the GNOME Code of Conduct</li>
+          <li>Add Polish translation</li>
+          <li>Spanish, Dutch, Croatian, Turkish, and German Translation Updates</li>
+        </ul>
+      </description>
+      <url>https://github.com/gaphor/gaphor/releases/tag/2.17.0</url>
+    </release>
+    <release version="2.16.0" date="2023-02-04">
+      <description>
+        <ul>
+          <li>Automatic switching to dark mode in diagrams</li>
+          <li>Add Model browser multi select and popup menu</li>
+          <li>Refactor and improve model browser</li>
+          <li>Use normal + icon for new diagram dropdown</li>
+          <li>Add support for CSS variables and named colors</li>
+          <li>Apply development mode for dev releases</li>
+          <li>Show diagram name in header</li>
+          <li>Show something when no diagrams are opened</li>
+          <li>Fix the packaged data dirs</li>
+          <li>Stabilize macOS/GTK tests</li>
+          <li>Add a comments option to our documentation</li>
+          <li>Split tips in to multiple labels</li>
+          <li>Win and macOS: Fix wrong language selected when region not default</li>
+          <li>Fix translation warning never logged with missing mo files</li>
+          <li>Spanish, Russian, Hungarian, Czech translation update</li>
+        </ul>
+      </description>
+      <url>https://github.com/gaphor/gaphor/releases/tag/2.16.0</url>
+    </release>
+    <release version="2.15.0" date="2023-01-08">
+      <description>
+        <ul>
+          <li>Add basic git merge conflict support by asking which model to load</li>
+          <li>Improvements to CSS autocomplete with function completion</li>
+          <li>Insert colons, spaces, and () automatically for CSS autocomplete</li>
+          <li>Use native file chooser in Windows</li>
+          <li>Fix translations not loading in Windows, macOS, and AppImage</li>
+          <li>Fix PyInstaller versionfile parse error with pre-release versions</li>
+          <li>Update CI to publish to PyPI after all other jobs have passed</li>
+          <li>Replace pytest-mock with monkeypatch for tests</li>
+          <li>Fix PEP597 encoding warnings</li>
+          <li>Fix regression that caused line handles to not snap to elements</li>
+          <li>Add Turkish, and update French, Russian, and Swedish translations</li>
+          <li>Remove translation Makefile</li>
+        </ul>
+      </description>
+      <url>https://github.com/gaphor/gaphor/releases/tag/2.15.0</url>
+    </release>
     <release version="2.14.2" date="2022-12-28" />
     <release version="2.14.1" date="2022-12-28" />
     <release version="2.14.0" date="2022-12-24" />

--- a/update-appdata.py
+++ b/update-appdata.py
@@ -6,6 +6,7 @@ import time
 import urllib.request
 from xml.etree import ElementTree as etree
 
+
 def update_release(appdata_file, version, date, notes):
     tree = etree.parse(appdata_file)
 
@@ -18,11 +19,8 @@ def update_release(appdata_file, version, date, notes):
 
 def find_release(tree, version, date):
     if (release := tree.find(f"./releases/release[@version='{version}']")) is None:
-        print("Creating a new release")
         release = etree.Element("release", attrib={"version": version, "date": date})
         tree.find("./releases").insert(0, release)
-    else:
-        print("Updating existing release")
 
     return release
 
@@ -67,6 +65,7 @@ def parse_news(news_text: str):
     news = {}
     current_version = None
     current_news = None
+
     for line in news_text.splitlines():
         if re.match("^\d+.\d+.\d+$", line):
             current_news = []
@@ -78,6 +77,7 @@ def parse_news(news_text: str):
             current_news[-1] = current_news[-1] + " " + line.strip()
         elif not line:
             current_version = None
+
     return news
 
 
@@ -94,7 +94,6 @@ def test_parse_news():
         - Feature one
         - Feature two
         """)
-
 
     news = parse_news(fragment)
 

--- a/update-appdata.py
+++ b/update-appdata.py
@@ -1,21 +1,125 @@
+import re
+import ssl
 import sys
+import textwrap
 import time
+import urllib.request
 from xml.etree import ElementTree as etree
 
-def update_release(appdata_file,version, date):
+def update_release(appdata_file, version, date, notes):
     tree = etree.parse(appdata_file)
 
-    releases = tree.find("./releases")
-    assert releases
-
-    release = etree.Element("release", attrib={"version": version, "date": date})
-    releases.insert(0, release)
+    release = find_release(tree, version, date)
+    update_release_details(release, version, notes)
 
     etree.indent(tree)
-
     tree.write(appdata_file, encoding="utf-8", xml_declaration=True)
 
 
+def find_release(tree, version, date):
+    if (release := tree.find(f"./releases/release[@version='{version}']")) is None:
+        print("Creating a new release")
+        release = etree.Element("release", attrib={"version": version, "date": date})
+        tree.find("./releases").insert(0, release)
+    else:
+        print("Updating existing release")
+
+    return release
+
+
+def test_find_release():
+    tree = etree.parse("share/org.gaphor.Gaphor.appdata.xml")
+
+    release = find_release(tree, "2.17.0", "DATE")
+
+    # Should have found the existing node
+    assert release.attrib["date"] != "DATE"
+
+
+def update_release_details(release, version, notes):
+    for node in release.findall("*"):
+        release.remove(node)
+
+    description = etree.SubElement(release, "description")
+    ul = etree.SubElement(description, "ul")
+    for note in notes:
+        li = etree.SubElement(ul, "li")
+        li.text = note
+
+    url = etree.SubElement(release, "url")
+    url.text = f"https://github.com/gaphor/gaphor/releases/tag/{version}"
+
+
+def download_news_from_github():
+    url = "https://raw.githubusercontent.com/gaphor/gaphor/main/NEWS"
+    with urllib.request.urlopen(url, context=ssl.create_default_context()) as response:
+        return response.read().decode(encoding="utf-8")
+
+
+def test_download_news_from_github():
+    news = download_news_from_github()
+
+    assert news
+    assert "2.18.0" in news
+
+
+def parse_news(news_text: str):
+    news = {}
+    current_version = None
+    current_news = None
+    for line in news_text.splitlines():
+        if re.match("^\d+.\d+.\d+$", line):
+            current_news = []
+            current_version = line
+            news[current_version] = current_news
+        elif current_version and re.match("^ *- +", line):
+            current_news.append(re.sub("^ *- +", "", line))
+        elif current_news and re.match("^ +\w", line):
+            current_news[-1] = current_news[-1] + " " + line.strip()
+        elif not line:
+            current_version = None
+    return news
+
+
+def test_parse_news():
+    fragment = textwrap.dedent("""\
+        2.1.0
+        ------
+        - Feature
+          three
+         - Feature four
+
+        2.0.0
+        ------
+        - Feature one
+        - Feature two
+        """)
+
+
+    news = parse_news(fragment)
+
+    assert "2.0.0" in news
+    assert "2.1.0" in news
+
+    assert "Feature one" in news["2.0.0"]
+    assert "Feature two" in news["2.0.0"]
+    assert "Feature three" in news["2.1.0"]
+    assert "Feature four" in news["2.1.0"]
+
+
+def run_tests():
+    for name, maybe_test in list(globals().items()):
+        if name.startswith("test_"):
+            print(name, "...", end="")
+            maybe_test()
+            print(" okay")
+
+
 if __name__ == "__main__":
-    today = time.strftime("%Y-%m-%d")
-    update_release("share/org.gaphor.Gaphor.appdata.xml", sys.argv[1], today)
+    if len(sys.argv) > 1:
+        version = sys.argv[1]
+        today = time.strftime("%Y-%m-%d")
+        news = parse_news(download_news_from_github())
+        update_release("share/org.gaphor.Gaphor.appdata.xml", version, today, news.get(version, ["Bug fixes."]))
+    else:
+        run_tests()

--- a/update-appdata.py
+++ b/update-appdata.py
@@ -1,0 +1,21 @@
+import sys
+import time
+from xml.etree import ElementTree as etree
+
+def update_release(appdata_file,version, date):
+    tree = etree.parse(appdata_file)
+
+    releases = tree.find("./releases")
+    assert releases
+
+    release = etree.Element("release", attrib={"version": version, "date": date})
+    releases.insert(0, release)
+
+    etree.indent(tree)
+
+    tree.write(appdata_file, encoding="utf-8", xml_declaration=True)
+
+
+if __name__ == "__main__":
+    today = time.strftime("%Y-%m-%d")
+    update_release("share/org.gaphor.Gaphor.appdata.xml", sys.argv[1], today)


### PR DESCRIPTION
I suppose we should be able to generate release notes from the NEWS file in Gaphor.

The idea is that each release should have a description and a link to the GH releases page:

```xml
<releases>
  <release version="1.2" date="2014-04-12" urgency="high">
    <description>
      <ul>
        <li>release line</li>
      </ul>
    </description>

    <url>https://example.org/releases/version-1.2.html</url>
  </release>
  ...
</releases>
```

A change history is prominent on the [Flathub page](https://flathub.org/apps/org.gaphor.Gaphor), so I suppose it would be best if we provide some useful information. Our NEWS file is a list of the most important changes in each release.

The release notes have been updates for all releases done in 2023.
