### PR TITLE
Add branding colors

### DIFF
--- a/share/org.gaphor.Gaphor.appdata.xml
+++ b/share/org.gaphor.Gaphor.appdata.xml
@@ -14,6 +14,10 @@
     <category>Development</category>
     <category>Graphics</category>
   </categories>
+  <branding>
+    <color type="primary" scheme_preference="light">#ccf5d4</color>
+    <color type="primary" scheme_preference="dark">#0f3f29</color>
+  </branding>
   <screenshots>
     <screenshot type="default">
       <caption>The Gaphor main window</caption>


### PR DESCRIPTION
This PR adds branding colors, which provides a background in FlatHub if the app is featured. I went with a color lighter than the lightest green for a light color, and darker than the darkest green for dark.

![light](https://github.com/flathub/org.gaphor.Gaphor/assets/10014976/8f01ca93-0e6d-4f78-8adf-aa62f9add6a0)
![dark](https://github.com/flathub/org.gaphor.Gaphor/assets/10014976/09900b16-99b9-4c2c-9d61-d854c35122fc)
