### PR TITLE
GNOME 46 + filesystem access

### DIFF
--- a/org.gaphor.Gaphor.yaml
+++ b/org.gaphor.Gaphor.yaml
@@ -1,6 +1,6 @@
 app-id: org.gaphor.Gaphor
 runtime: org.gnome.Platform
-runtime-version: '45'
+runtime-version: '46'
 sdk: org.gnome.Sdk
 command: gaphor
 finish-args:
@@ -8,6 +8,7 @@ finish-args:
   - --share=ipc
   - --socket=wayland
   - --device=dri
+  - --filesystem=home
 cleanup:
   - /include
 modules:


### PR DESCRIPTION
* Use GNOME 46
* Add back direct filesystem access. This is required for the merge-conflict resolver.