### PR TITLE
Explicitly install Python to fix Gaphor version not found

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -8,6 +8,9 @@ on:
   repository_dispatch:
     types: [version-update]
 
+env:
+  python_version: '3.12'
+
 permissions:
   contents: write 
   pull-requests: write
@@ -16,13 +19,16 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.4
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
+        with:
+          python-version: ${{ env.python_version }}
       - name: Update version
         run: |
           if test -z "${{ github.event.inputs.version }}${{ github.event.client_payload.version }}"; then echo "No version provided"; exit 1; fi
           make only-update VERSION=${{ github.event.inputs.version }}${{ github.event.client_payload.version }}
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6.0.5
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
         with:
           commit-message: update to version ${{ github.event.inputs.version }}${{ github.event.client_payload.version }}
           title: Update to version ${{ github.event.inputs.version }}${{ github.event.client_payload.version }}


### PR DESCRIPTION
During trigger builds, we are getting a `Could not find a version that matches distribution` error from PyPI when it is searching for the new gaphor release by version, even after 20+ minutes after the version has been published to PyPI. It is working fine locally. This PR attempts to fix that by explicitly setting up Python with the pinned latest version.