### PR TITLE
update runtime: GNOME 48

### DIFF
--- a/org.gaphor.Gaphor.yaml
+++ b/org.gaphor.Gaphor.yaml
@@ -1,6 +1,6 @@
 app-id: org.gaphor.Gaphor
 runtime: org.gnome.Platform
-runtime-version: '47'
+runtime-version: '48'
 sdk: org.gnome.Sdk
 command: gaphor
 finish-args:


### PR DESCRIPTION
New runtime includes LibAdwaita 1.7, which tweaks colors for the dark theme and corner radius for windows and widgets.