### PR TITLE
Automatically update Graphviz versions

### DIFF
--- a/depends.sh
+++ b/depends.sh
@@ -30,3 +30,20 @@ do
 	echo "    url: ${URL}"
 	echo "    sha256: ${SHA}"
 done
+
+GRAPHVIZ_TAG=$(curl -sSfL "https://gitlab.com/api/v4/projects/4207231/repository/tags?per_page=10" | jq -r '.[] | select(.name | test("^[0-9]+\\.[0-9]+\\.[0-9]+$")) | .name' | head -1)
+GRAPHVIZ_VERSION=${GRAPHVIZ_TAG:-14.0.2}
+GRAPHVIZ_SHA256_URL="https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/${GRAPHVIZ_VERSION}/graphviz-${GRAPHVIZ_VERSION}.tar.xz.sha256"
+
+GRAPHVIZ_SHA256=$(curl -sSfL "${GRAPHVIZ_SHA256_URL}" | cut -d' ' -f1)
+
+if [ -n "${GRAPHVIZ_SHA256}" ]; then
+	OLD_VERSION=$(grep -oE '[0-9]+\.[0-9]+\.[0-9]+' graphviz.yaml | head -1)
+	
+	sed -i \
+		-e "s/${OLD_VERSION}/${GRAPHVIZ_VERSION}/g" \
+		-e "s/sha256: [a-f0-9]*/sha256: ${GRAPHVIZ_SHA256}/" \
+		graphviz.yaml
+else
+	echo "Warning: Could not fetch graphviz SHA256 for version ${GRAPHVIZ_VERSION}, keeping existing version" >&2
+fi


### PR DESCRIPTION
When running `make update VERSION` it should pull in the latest version of Graphviz. This PR updates the depends.sh to get the latest version and update the graphviz manifest.