### PR TITLE
Revert "Gaphor 3.3.0"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 
 ID := org.gaphor.Gaphor
 # Do not change version by hand!
-VERSION := 3.3.0
+VERSION := 3.2.0
 
 BUILD := build
 DIST := dist

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Flatpak dependencies:
 
 ```
 flatpak remote-add flathub --user --if-not-exists https://flathub.org/repo/flathub.flatpakrepo
-flatpak install --user flathub org.gnome.Sdk//50
-flatpak install --user flathub org.gnome.Platform//50
+flatpak install --user flathub org.gnome.Sdk//48
+flatpak install --user flathub org.gnome.Platform//48
 ```
 
 Alternatively, you can run `make setup` which will install all required dependencies.

--- a/depends.sh
+++ b/depends.sh
@@ -30,20 +30,3 @@ do
 	echo "    url: ${URL}"
 	echo "    sha256: ${SHA}"
 done
-
-GRAPHVIZ_TAG=$(curl -sSfL "https://gitlab.com/api/v4/projects/4207231/repository/tags?per_page=10" | jq -r '.[] | select(.name | test("^[0-9]+\\.[0-9]+\\.[0-9]+$")) | .name' | head -1)
-GRAPHVIZ_VERSION=${GRAPHVIZ_TAG:-14.0.2}
-GRAPHVIZ_SHA256_URL="https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/${GRAPHVIZ_VERSION}/graphviz-${GRAPHVIZ_VERSION}.tar.xz.sha256"
-
-GRAPHVIZ_SHA256=$(curl -sSfL "${GRAPHVIZ_SHA256_URL}" | cut -d' ' -f1)
-
-if [ -n "${GRAPHVIZ_SHA256}" ]; then
-	OLD_VERSION=$(grep -oE '[0-9]+\.[0-9]+\.[0-9]+' graphviz.yaml | head -1)
-	
-	sed -i \
-		-e "s/${OLD_VERSION}/${GRAPHVIZ_VERSION}/g" \
-		-e "s/sha256: [a-f0-9]*/sha256: ${GRAPHVIZ_SHA256}/" \
-		graphviz.yaml
-else
-	echo "Warning: Could not fetch graphviz SHA256 for version ${GRAPHVIZ_VERSION}, keeping existing version" >&2
-fi

--- a/gaphor-bin.yaml
+++ b/gaphor-bin.yaml
@@ -5,29 +5,35 @@ build-commands:
   - pip3 install --no-index --no-cache-dir --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} gaphor
 sources:
   - type: file
-    url: https://files.pythonhosted.org/packages/af/d4/17454d1b5c3cfa1368752aba1e8019c861487f08d87a4f2b1ec773761873/gaphor-3.3.0-py3-none-any.whl
-    sha256: ccb61b6fa2946035e45d7878d4a0ae497fc8eb4c7c0767cfb4231107505ba150
+    url: https://files.pythonhosted.org/packages/29/20/af84f4f7b616f2ce60595198a112bac235bf907c20dd38bb8cd723cc3478/gaphor-3.2.0-py3-none-any.whl
+    sha256: c1e2e3324b04ae064600019ab06f2f775462397b6a7b58566c97d93b8f04dc6a
+  - type: file
+    url: https://files.pythonhosted.org/packages/d4/8b/0f2de00c0c0d5881dc39be147ec2918725fb3628deeeb1f27d1c6cf6d9f4/dulwich-0.22.8.tar.gz
+    sha256: 701547310415de300269331abe29cb5717aa1ea377af826bf513d0adfb1c209b
   - type: file
     url: https://files.pythonhosted.org/packages/c0/5a/9cac0c82afec3d09ccd97c8b6502d48f165f9124db81b4bcb90b4af974ee/jedi-0.19.2-py2.py3-none-any.whl
     sha256: a8ef22bde8490f57fe5c7681a3c83cb58874daf72b4784de3cce5b6ef6edb5b9
   - type: file
-    url: https://files.pythonhosted.org/packages/b6/61/fae042894f4296ec49e3f193aff5d7c18440da9e48102c3315e1bc4519a7/parso-0.8.6-py2.py3-none-any.whl
-    sha256: 2c549f800b70a5c4952197248825584cb00f033b29c692671d3bf08bf380baff
+    url: https://files.pythonhosted.org/packages/16/32/f8e3c85d1d5250232a5d3477a2a28cc291968ff175caeadaf3cc19ce0e4a/parso-0.8.5-py2.py3-none-any.whl
+    sha256: 646204b5ee239c396d040b90f9e272e9a8017c630092bf59980beb62fd033887
   - type: file
-    url: https://files.pythonhosted.org/packages/b7/29/c12876926be20e100527f541c792731ea09b995139aee9676eaacd1b751e/setuptools_rust-1.12.1-py3-none-any.whl
-    sha256: b7ebd6a182e7aefa97a072e880530c9b0ec8fcca8617e0bb8ff299c1a064f693
+    url: https://files.pythonhosted.org/packages/b0/5f/1ebfd430df05c4f9e438dd3313c4456eab937d976f6ab8ce81a98f9fb381/pydot-3.0.4-py3-none-any.whl
+    sha256: bfa9c3fc0c44ba1d132adce131802d7df00429d1a79cc0346b0a5cd374dbe9c6
+  - type: file
+    url: https://files.pythonhosted.org/packages/f9/7b/d05b1778f2d4e354d103e3421c6267d923032fefcc5ca5b7df0cb21cefd0/setuptools_rust-1.12.0-py3-none-any.whl
+    sha256: 7e7db90547f224a835b45f5ad90c983340828a345554a9a660bdb2de8605dcdd
   - type: file
     url: https://files.pythonhosted.org/packages/6a/23/8146aad7d88f4fcb3a6218f41a60f6c2d4e3a72de72da1825dc7c8f7877c/semantic_version-2.10.0-py2.py3-none-any.whl
     sha256: de78a3b8e0feda74cabc54aab2da702113e33ac9d9eb9d2389bcf1f58b7d9177
   - type: file
-    url: https://files.pythonhosted.org/packages/87/22/b76d483683216dde3d67cba61fb2444be8d5be289bf628c13fc0fd90e5f9/wheel-0.46.3-py3-none-any.whl
-    sha256: 4b399d56c9d9338230118d705d9737a2a468ccca63d5e813e2a4fc7815d8bc4d
+    url: https://files.pythonhosted.org/packages/0b/2c/87f3254fd8ffd29e4c02732eee68a83a1d3c346ae39bc6822dcbcb697f2b/wheel-0.45.1-py3-none-any.whl
+    sha256: 708e7481cc80179af0e556bbf0cc00b8444c7321e2700b8d8580231d13017248
   - type: file
-    url: https://files.pythonhosted.org/packages/ab/87/99f21e9b20899d6dc1bf7544cfe53e5fa17acc21bb267971a540425357d3/pybind11-3.0.3-py3-none-any.whl
-    sha256: fb5f8e4a64946b4dcc0451c83a8c384f803bc0a62dd1ba02f199e97dbc9aad4c
+    url: https://files.pythonhosted.org/packages/cd/8a/37362fc2b949d5f733a8b0f2ff51ba423914cabefe69f1d1b6aab710f5fe/pybind11-3.0.1-py3-none-any.whl
+    sha256: aa8f0aa6e0a94d3b64adfc38f560f33f15e589be2175e103c0a33c6bce55ee89
   - type: file
-    url: https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl
-    sha256: e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35
+    url: https://files.pythonhosted.org/packages/b7/b8/3fe70c75fe32afc4bb507f75563d39bc5642255d1d94f1f23604725780bf/babel-2.17.0-py3-none-any.whl
+    sha256: 4d0b53093fdfb4b21c92b5213dba5a1b23885afa8383709427046b21c366e5f2
   - type: file
     url: https://files.pythonhosted.org/packages/ed/50/abf6850135f1e95d321a525d0a36e05255a039b3fc118b7d88413e8a8207/better_exceptions-0.3.3-py3-none-any.whl
     sha256: 9c70b1c61d5a179b84cd2c9d62c3324b667d74286207343645ed4306fdaad976
@@ -35,41 +41,32 @@ sources:
     url: https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl
     sha256: a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61
   - type: file
-    url: https://files.pythonhosted.org/packages/02/c4/bfe2a4e5b203f87ea925339691dd6e379e1a80d805dff0502e496bcaec39/dulwich-1.1.0.tar.gz
-    sha256: 9aa855db9fee0a7065ae9ffb38e14e353876d82f17e33e1a1fb3830eb8d0cf43
+    url: https://files.pythonhosted.org/packages/e5/fa/8f9c4145352599dd26b2779862901fdd12bbe056da0e3b4a652647806c3c/gaphas-5.1.1-py3-none-any.whl
+    sha256: b92697332f3dc889a15a1dad32325ef00fc190d869fd3b4eefcc47b280174b74
   - type: file
-    url: https://files.pythonhosted.org/packages/71/c2/03e1d69be2fe316250a3e2116a9ff811313b074d069162da9cbff5026c62/gaphas-5.1.2-py3-none-any.whl
-    sha256: e2f5fcbab3d8278eacfb13529551608ecfdc45ac580fd8f22dff5964efb5b1d0
+    url: https://files.pythonhosted.org/packages/4c/c9/729ceabda36c103e00b26e32ae0ad1ec22a8f679f989957fbc01cefc05fe/generic-1.1.5-py3-none-any.whl
+    sha256: d7b2cafd07542d2ead79d7e878d68bdbcb3c03cbbf359d5b902e9ff69164ccba
   - type: file
-    url: https://files.pythonhosted.org/packages/68/6d/459ded13938c2f2dadf71e107f78001d30b8466fda3acac27a55934b246e/generic-1.1.7-py3-none-any.whl
-    sha256: 9048a52debd50e6d7671bb44826567a9c81d2e8302253179adfb8054ab415077
+    url: https://files.pythonhosted.org/packages/5a/b0/cace85a1b0c9775a9f8f5d5423c8261c858760e2466c79b2dd184638b056/pillow-12.0.0.tar.gz
+    sha256: 87d4f8125c9988bfbed67af47dd7a953e2fc7b0cc1e7800ec6d2080d490bb353
   - type: file
-    url: https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl
-    sha256: b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529
+    url: https://files.pythonhosted.org/packages/40/d9/412da520de9052b7e80bfc810ec10f5cb3dbfa4aa3e23c2820dc61cdb3d0/pycairo-1.28.0.tar.gz
+    sha256: 26ec5c6126781eb167089a123919f87baa2740da2cca9098be8b3a6b91cc5fbc
   - type: file
-    url: https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz
-    sha256: a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5
+    url: https://files.pythonhosted.org/packages/d3/a5/68f883df1d8442e3b267cb92105a4b2f0de819bd64ac9981c2d680d3f49f/pygobject-3.54.5.tar.gz
+    sha256: b6656f6348f5245606cf15ea48c384c7f05156c75ead206c1b246c80a22fb585
   - type: file
-    url: https://files.pythonhosted.org/packages/22/d9/1728840a22a4ef8a8f479b9156aa2943cd98c3907accd3849fb0d5f82bfd/pycairo-1.29.0.tar.gz
-    sha256: f3f7fde97325cae80224c09f12564ef58d0d0f655da0e3b040f5807bd5bd3142
+    url: https://files.pythonhosted.org/packages/10/5e/1aa9a93198c6b64513c9d7752de7422c06402de6600a8767da1524f9570b/pyparsing-3.2.5-py3-none-any.whl
+    sha256: e38a4f02064cf41fe6593d328d0512495ad1f3d8a91c4f73fc401b3079a59a5e
   - type: file
-    url: https://files.pythonhosted.org/packages/7e/32/a7125fb28c4261a627f999d5fb4afff25b523800faed2c30979949d6facd/pydot-4.0.1-py3-none-any.whl
-    sha256: 869c0efadd2708c0be1f916eb669f3d664ca684bc57ffb7ecc08e70d5e93fee6
+    url: https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl
+    sha256: 062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922
   - type: file
-    url: https://files.pythonhosted.org/packages/a2/80/09247a2be28af2c2240132a0af6c1005a2b1d089242b13a2cd782d2de8d7/pygobject-3.56.2.tar.gz
-    sha256: b816098969544081de9eecedb94ad6ac59c77e4d571fe7051f18bebcec074313
+    url: https://files.pythonhosted.org/packages/e6/34/ebdc18bae6aa14fbee1a08b63c015c72b64868ff7dae68808ab500c492e2/tinycss2-1.4.0-py3-none-any.whl
+    sha256: 3a49cf47b7675da0b15d0c6e1df8df4ebd96e9394bb905a5775adb0d884c5289
   - type: file
-    url: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
-    sha256: 850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d
-  - type: file
-    url: https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl
-    sha256: a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb
-  - type: file
-    url: https://files.pythonhosted.org/packages/60/45/c7b5c3168458db837e8ceab06dc77824e18202679d0463f0e8f002143a97/tinycss2-1.5.1-py3-none-any.whl
-    sha256: 3415ba0f5839c062696996998176c4a3751d18b7edaaeeb658c9ce21ec150661
-  - type: file
-    url: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
-    sha256: bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4
+    url: https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl
+    sha256: e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc
   - type: file
     url: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
     sha256: a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78

--- a/graphviz.yaml
+++ b/graphviz.yaml
@@ -1,13 +1,13 @@
 name: graphviz
 buildsystem: simple
 build-commands:
-  - tar xf graphviz-14.1.5.tar.xz
-  - cd graphviz-14.1.5 && ./configure --prefix=${FLATPAK_DEST}  --without-x --with-qt=no --with-gtk=no --enable-swig=no --with-webp=no --with-rsvg=no --with-visio=no --with-gdk-pixbuf=no --with-pangocairo=no
-  - cd graphviz-14.1.5 && make install
+  - tar xf graphviz-14.0.2.tar.xz
+  - cd graphviz-14.0.2 && ./configure --prefix=${FLATPAK_DEST}  --without-x --with-qt=no --with-gtk=no --enable-swig=no --with-webp=no --with-rsvg=no --with-visio=no --with-gdk-pixbuf=no --with-pangocairo=no
+  - cd graphviz-14.0.2 && make install
 cleanup:
   - /share/man
   - /share/graphviz
 sources:
   - type: file
-    url: https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/14.1.5/graphviz-14.1.5.tar.xz
-    sha256: b017378835f7ca12f1a3f1db5c338d7e7af16b284b7007ad73ccec960c1b45b3
+    url: https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/14.0.2/graphviz-14.0.2.tar.xz
+    sha256: 31af4728cd0d7db91013d29286227ae6b5264ff897647c2ebfeb85f47c08177e

--- a/org.gaphor.Gaphor.yaml
+++ b/org.gaphor.Gaphor.yaml
@@ -1,6 +1,6 @@
 app-id: org.gaphor.Gaphor
 runtime: org.gnome.Platform
-runtime-version: '50'
+runtime-version: '48'
 sdk: org.gnome.Sdk
 command: gaphor
 finish-args:

--- a/share/org.gaphor.Gaphor.appdata.xml
+++ b/share/org.gaphor.Gaphor.appdata.xml
@@ -99,30 +99,6 @@
     </p>
   </description>
   <releases>
-    <release version="3.3.0" date="2026-04-12">
-      <description>
-        <ul>
-          <li>Add HTML report generator</li>
-          <li>Add an initial doodling language with simple shapes</li>
-          <li>Add help menu for documentation</li>
-          <li>Update styling of shortcuts menu</li>
-          <li>Stereotype updates for interfaces and operations</li>
-          <li>Automatically update new releases on winget</li>
-        </ul>
-        <p>Internal changes:</p>
-        <ul>
-          <li>Improvements to simplify packaging</li>
-          <li>Fix codespaces by updating the base image</li>
-        </ul>
-        <p>Bug fixes:</p>
-        <ul>
-          <li>macOS: Fix Gaphor crashes when dragging elements to a diagram</li>
-          <li>Ensure Italian translations are built</li>
-          <li>Fix crash when running gaphor with the <code>--profile</code> option</li>
-        </ul>
-      </description>
-      <url>https://github.com/gaphor/gaphor/releases/tag/3.3.0</url>
-    </release>
     <release version="3.2.0" date="2025-11-09">
       <description>
         <ul>


### PR DESCRIPTION
Reverts flathub/org.gaphor.Gaphor#124 until the GNOME 50.1 runtime is released later this week in order to fix custom icons failing to render. See https://github.com/gaphor/gaphor/issues/4217.